### PR TITLE
Implement getAllUserData in chat-with-data route

### DIFF
--- a/server/api/openai/chat-with-data.ts
+++ b/server/api/openai/chat-with-data.ts
@@ -1,10 +1,15 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { streamText } from 'ai';
-import { ref, watch, computed } from 'vue'
 import { z } from 'zod';
-import { serverSupabaseClient } from '#supabase/server';
+import { serverSupabaseClient } from '#supabase/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
 import { getUserData } from '@/server/utils/getUserData'
+
+async function getAllUserData(supabase: SupabaseClient, userId: string) {
+  const data = await getUserData(supabase, userId)
+  return { userData: data }
+}
 
 export default defineLazyEventHandler(async () => {
   const openai = createOpenAI({
@@ -30,10 +35,7 @@ export default defineLazyEventHandler(async () => {
         getAllUserData: {
           description: 'Return all mood-entry data for the signed-in user',
           parameters: z.object({}),
-          execute: async () => {
-            const data = await getUserData(supabase, user.id)
-            return { userData: data }
-          },
+          execute: async () => getAllUserData(supabase, user.id),
         },
       },
     });


### PR DESCRIPTION
## Summary
- implement `getAllUserData` helper to fetch all mood entries
- use helper inside OpenAI `chat-with-data` API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68401004ce408330aeb3adb74a20f77f