### PR TITLE
Add Spotify track details to mood entries

### DIFF
--- a/components/MoodCalendar.vue
+++ b/components/MoodCalendar.vue
@@ -222,6 +222,8 @@
   entry_timestamp: string;
   general_mood: number;
   spotify_song_id?: string;
+  spotify_song_name?: string;
+  spotify_song_artist?: string;
   notes?: string;
   detailed_moods?: { mood_name: string }[];
   social_contexts?: { social_name: string }[];

--- a/components/Moods.vue
+++ b/components/Moods.vue
@@ -30,6 +30,8 @@
       <div class="flex-shrink-0 w-full p-4" v-if="isAuthenticated">
         <SpotifySearch
           v-model:spotifySongId="songId"
+          v-model:spotifySongName="songName"
+          v-model:spotifySongArtist="songArtist"
         />
       </div>
 
@@ -41,6 +43,8 @@
           :locationContext="selectedLocations"
           :socialContext="selectedSocials"
           :spotifySongId="songId"
+          :spotifySongName="songName"
+          :spotifySongArtist="songArtist"
         />
       </div>
     </div>
@@ -92,6 +96,8 @@
   const selectedLocations = ref<number[]>([])
   const selectedSocials   = ref<number[]>([])
   const songId            = ref<string|null>(null)
+  const songName          = ref<string|null>(null)
+  const songArtist        = ref<string|null>(null)
 
   const isFirst = computed(() => current.value === 0)
   const isLast  = computed(() => current.value === slides.value - 1)

--- a/components/NoteConfirmation.vue
+++ b/components/NoteConfirmation.vue
@@ -31,6 +31,8 @@ const props = defineProps<{
   locationContext: number[]
   socialContext: number[]
   spotifySongId: string | null
+  spotifySongName: string | null
+  spotifySongArtist: string | null
 }>()
 
 const notes = ref('')
@@ -47,7 +49,9 @@ async function submit() {
       location_ids: props.locationContext,
       social_ids: props.socialContext,
       notes: notes.value,
-      spotify_song_id: props.spotifySongId
+      spotify_song_id: props.spotifySongId,
+      spotify_song_name: props.spotifySongName,
+      spotify_song_artist: props.spotifySongArtist
     }
 
     const { enc_iv, enc_blob } = await seal(payload)

--- a/components/SpotifySearch.vue
+++ b/components/SpotifySearch.vue
@@ -40,19 +40,31 @@ import { ref, watch } from 'vue'
 
 const props = defineProps<{
   spotifySongId: string | null
+  spotifySongName: string | null
+  spotifySongArtist: string | null
 }>()
 
 const emit = defineEmits<{
   (e: 'update:spotifySongId', value: string | null): void
+  (e: 'update:spotifySongName', value: string | null): void
+  (e: 'update:spotifySongArtist', value: string | null): void
 }>()
 
 const q               = ref('')
 const tracks          = ref<any[]>([])
 const localSelectedId = ref<string | null>(props.spotifySongId)
+const localSelectedName = ref<string | null>(props.spotifySongName)
+const localSelectedArtist = ref<string | null>(props.spotifySongArtist)
 const displayedId     = ref<string | null>(null)
 
 watch(() => props.spotifySongId, v => {
   localSelectedId.value = v
+})
+watch(() => props.spotifySongName, v => {
+  localSelectedName.value = v
+})
+watch(() => props.spotifySongArtist, v => {
+  localSelectedArtist.value = v
 })
 
 async function doSearch() {
@@ -79,12 +91,16 @@ async function doSearch() {
 
 function onTrackClick(track: any) {
   localSelectedId.value = track.id
+  localSelectedName.value = track.name
+  localSelectedArtist.value = track.artists.map((a: any) => a.name).join(', ')
   displayedId.value     = null
 }
 
 function onContinue() {
   displayedId.value = localSelectedId.value
   emit('update:spotifySongId', localSelectedId.value)
+  emit('update:spotifySongName', localSelectedName.value)
+  emit('update:spotifySongArtist', localSelectedArtist.value)
 }
 </script>
 

--- a/composables/usePublicContextData.ts
+++ b/composables/usePublicContextData.ts
@@ -55,6 +55,8 @@ export function usePublicContextData() {
             general_mood: generalMap[p.general_mood] || null,
             notes: p.notes,
             spotify_song_id: p.spotify_song_id ?? null,
+            spotify_song_name: p.spotify_song_name ?? null,
+            spotify_song_artist: p.spotify_song_artist ?? null,
             detailed_moods: (p.detailed_ids ?? []).map(id => detailedMap[id]).filter(Boolean),
             location_contexts: (p.location_ids ?? []).map(id => locationMap[id]).filter(Boolean),
             social_contexts: (p.social_ids ?? []).map(id => socialMap[id]).filter(Boolean)


### PR DESCRIPTION
## Summary
- enhance Spotify search to emit track name & artist
- pass selected track details from Moods to NoteConfirmation
- store spotify_song_name and spotify_song_artist in mood entry payload
- enrich mood entries with new Spotify fields
- extend MoodCalendar entry type to include track details

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842f35f45208330b112e18854f25fc8