### PR TITLE
Add Spotify top songs tool for chat

### DIFF
--- a/server/api/openai/chat-with-data.ts
+++ b/server/api/openai/chat-with-data.ts
@@ -1,8 +1,8 @@
 import { createOpenAI } from '@ai-sdk/openai';
 import { streamText } from 'ai';
-import { ref, watch, computed } from 'vue'
 import { z } from 'zod';
 import { serverSupabaseClient } from '#supabase/server';
+import { getCookie, setCookie, createError } from 'h3'
 
 import { getUserData } from '@/server/utils/getUserData'
 
@@ -33,6 +33,53 @@ export default defineLazyEventHandler(async () => {
           execute: async () => {
             const decrypted = data?.userData ?? await getUserData(supabase, user.id)
             return { userData: decrypted }
+          },
+        },
+
+        getUserTopSongs: {
+          description: 'Return the user\'s top 10 Spotify tracks and artists',
+          parameters: z.object({
+            timeframe: z.enum(['short_term', 'medium_term', 'long_term']).default('short_term'),
+          }),
+          execute: async ({ timeframe }) => {
+            let token = getCookie(event, 'spotify_access_token')
+            if (!token) {
+              throw createError({ statusCode: 401, statusMessage: 'Not authenticated with Spotify' })
+            }
+
+            const fetchTracks = () =>
+              $fetch(`https://api.spotify.com/v1/me/top/tracks?time_range=${timeframe}`, {
+                headers: { Authorization: `Bearer ${token}` },
+                params: { limit: '10' },
+              })
+            const fetchArtists = () =>
+              $fetch(`https://api.spotify.com/v1/me/top/artists?time_range=${timeframe}`, {
+                headers: { Authorization: `Bearer ${token}` },
+                params: { limit: '10' },
+              })
+
+            try {
+              const [{ items: tracks }, { items: artists }]: any = await Promise.all([
+                fetchTracks(),
+                fetchArtists(),
+              ])
+              return { tracks, artists }
+            } catch (err: any) {
+              if (err._data?.error?.status === 401) {
+                const { access_token: newToken, expires_in }: any = await $fetch('/api/spotify/refresh')
+                token = newToken
+                setCookie(event, 'spotify_access_token', newToken, {
+                  httpOnly: true,
+                  maxAge: expires_in,
+                })
+                const [{ items: tracks }, { items: artists }]: any = await Promise.all([
+                  fetchTracks(),
+                  fetchArtists(),
+                ])
+                return { tracks, artists }
+              }
+              throw err
+            }
           },
         },
       },


### PR DESCRIPTION
## Summary
- expose user top Spotify tracks & artists to the LLM

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843390120a48330a75ce78c9b57587d