### PR TITLE
Center header and mood icons update

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,7 +1,8 @@
 <template>
-<nav class="bg-transparent text-white px-6 py-4 flex items-center justify-between" aria-label="Main menu">
-  <!-- Mobile Layout -->
-  <div class="flex md:hidden items-center justify-between w-full">
+<nav class="bg-transparent text-white px-6 py-4" aria-label="Main menu">
+  <div class="max-w-screen-xl mx-auto flex items-center justify-between">
+    <!-- Mobile Layout -->
+    <div class="flex md:hidden items-center justify-between w-full">
     <!-- Left: Logo + Hamburger -->
     <div class="flex items-center space-x-3">
       <!-- Hamburger Menu -->
@@ -193,6 +194,7 @@
         </div>
       </div>
     </div>
+  </div>
   </div>
 </nav>
 </template>

--- a/components/MoodSelector.vue
+++ b/components/MoodSelector.vue
@@ -28,7 +28,7 @@
           class="flex-shrink-0 mr-3 p-2 rounded-full border-2 emoji-circle"
           :class="{ 'selected-circle': selected === opt.value }"
         >
-          <span>{{ opt.emoji }}</span>
+          <img :src="opt.icon" alt="mood" class="w-6 h-6" />
         </div>
 
         <span style="color: var(--fg)">{{ opt.label }}</span>
@@ -40,6 +40,11 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
 import { useSupabaseClient, useSupabaseUser } from '#imports'
+import mood1Url from '@/assets/images/1.svg'
+import mood2Url from '@/assets/images/2.svg'
+import mood3Url from '@/assets/images/3.svg'
+import mood4Url from '@/assets/images/4.svg'
+import mood5Url from '@/assets/images/5.svg'
 
 const props = defineProps({
   modelValue: { type: Number, default: 0 }
@@ -57,11 +62,11 @@ watch(localValue, v => {
 
 // mood options
 const options = [
-  { value: 1, label: 'Great', emoji: '😃' },
-  { value: 2, label: 'Good',  emoji: '🙂' },
-  { value: 3, label: 'Fine',  emoji: '😐' },
-  { value: 4, label: 'Bad',   emoji: '☹️' },
-  { value: 5, label: 'Awful', emoji: '😫' },
+  { value: 1, label: 'Great', icon: mood1Url },
+  { value: 2, label: 'Good',  icon: mood2Url },
+  { value: 3, label: 'Fine',  icon: mood3Url },
+  { value: 4, label: 'Bad',   icon: mood4Url },
+  { value: 5, label: 'Awful', icon: mood5Url },
 ]
 
 const selected = computed(() => localValue.value)


### PR DESCRIPTION
## Summary
- keep header content centered by limiting header width
- show mood selection with svg icons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684365df20008330b895fe2ac2072c2f