### PR TITLE
Add mood analytics page

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -97,6 +97,13 @@
           >
             <svg style="fill:#1DB954" xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="currentColor"  class="icon icon-tabler icons-tabler-filled icon-tabler-brand-spotify"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M17 3.34a10 10 0 1 1 -15 8.66l.005 -.324a10 10 0 0 1 14.995 -8.336m-2.168 11.605c-1.285 -1.927 -4.354 -2.132 -6.387 -.777a1 1 0 0 0 1.11 1.664c1.195 -.797 3.014 -.675 3.613 .223a1 1 0 1 0 1.664 -1.11m1.268 -3.245c-2.469 -1.852 -5.895 -2.187 -8.608 -.589a1 1 0 0 0 1.016 1.724c1.986 -1.171 4.544 -.92 6.392 .465a1 1 0 0 0 1.2 -1.6m1.43 -3.048c-3.677 -2.298 -7.766 -2.152 -10.977 -.546a1 1 0 0 0 .894 1.788c2.635 -1.317 5.997 -1.437 9.023 .454a1 1 0 1 0 1.06 -1.696" /></svg>
           </NuxtLink>
+          <NuxtLink
+            to="/analytics"
+            @click="showMobileMenu = false"
+            class="flex items-center justify-center p-3 rounded-xl hover:bg-gray-600 transition-colors duration-200"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19v-6"/><path d="M9 19v-11"/><path d="M14 19v-8"/><path d="M19 19v-14"/></svg>
+          </NuxtLink>
           
         </div>
 
@@ -120,13 +127,21 @@
             <span class="text-lg font-semibold">AI chat</span>
           </NuxtLink>
           
-          <NuxtLink 
-            to="/diary" 
+          <NuxtLink
+            to="/diary"
             @click="showMobileMenu = false"
             class="flex items-center space-x-3 p-3 text-white hover:bg-[var(--highlighted)] rounded-lg transition-colors duration-200"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
             <span class="text-lg font-semibold">Diary</span>
+          </NuxtLink>
+          <NuxtLink
+            to="/analytics"
+            @click="showMobileMenu = false"
+            class="flex items-center space-x-3 p-3 text-white hover:bg-[var(--highlighted)] rounded-lg transition-colors duration-200"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19v-6"/><path d="M9 19v-11"/><path d="M14 19v-8"/><path d="M19 19v-14"/></svg>
+            <span class="text-lg font-semibold">Analytics</span>
           </NuxtLink>
         </div>
       </div>
@@ -161,6 +176,9 @@
       </NuxtLink>
       <NuxtLink to="/diary" class="text-md font-semibold nav-link text-white duration-200 no-underline">
         Diary
+      </NuxtLink>
+      <NuxtLink to="/analytics" class="text-md font-semibold nav-link text-white duration-200 no-underline">
+        Analytics
       </NuxtLink>
       <NuxtLink to="/calendar" class="text-sm font-semibold nav-link text-white duration-200 no-underline">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vee-validate/nuxt": "^4.15.0",
         "ai": "^4.3.16",
         "base-64": "^1.0.0",
+        "chart.js": "^4.4.9",
         "cookie": "^0.7.2",
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.5",
@@ -29,6 +30,7 @@
         "tailwindcss": "^4.1.4",
         "vite-tsconfig-paths": "^5.1.4",
         "vue": "^3.5.13",
+        "vue-chartjs": "^5.3.2",
         "vue-router": "^4.5.0",
         "zxcvbn": "^4.4.2"
       },
@@ -1112,6 +1114,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -3958,6 +3966,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -9990,6 +10010,16 @@
       "license": "MIT",
       "dependencies": {
         "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-devtools-stub": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vee-validate/nuxt": "^4.15.0",
     "ai": "^4.3.16",
     "base-64": "^1.0.0",
+    "chart.js": "^4.4.9",
     "cookie": "^0.7.2",
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.5",

--- a/pages/analytics.vue
+++ b/pages/analytics.vue
@@ -1,0 +1,91 @@
+<template>
+  <ClientOnly>
+    <div class="p-6 space-y-10">
+      <h1 class="text-2xl font-bold text-center">Mood Analytics</h1>
+      <div>
+        <canvas ref="weeklyChartRef" class="w-full max-w-3xl mx-auto"></canvas>
+      </div>
+      <div>
+        <canvas ref="monthlyChartRef" class="w-full max-w-3xl mx-auto"></canvas>
+      </div>
+    </div>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+import { Chart, registerables } from 'chart.js'
+import { parseISO, getWeek, format } from 'date-fns'
+import { useMoodEntries } from '~/composables/useMoodEntries'
+
+Chart.register(...registerables)
+
+definePageMeta({ requiresAuth: true })
+
+const { finalizedEntries, fetchFinalizedMoodEntries } = useMoodEntries()
+
+const weeklyChartRef = ref<HTMLCanvasElement | null>(null)
+const monthlyChartRef = ref<HTMLCanvasElement | null>(null)
+let weeklyChart: Chart | null = null
+let monthlyChart: Chart | null = null
+
+onMounted(async () => {
+  await fetchFinalizedMoodEntries()
+  buildCharts()
+})
+
+watch(finalizedEntries, buildCharts)
+
+function buildCharts() {
+  if (!weeklyChartRef.value || !monthlyChartRef.value) return
+  const entries = finalizedEntries.value
+  if (!entries.length) return
+
+  // group moods by week
+  const weekMap: Record<string, number[]> = {}
+  const monthMap: Record<string, number[]> = {}
+  for (const e of entries) {
+    const d = parseISO(e.payload.entry_timestamp)
+    const weekKey = `${d.getFullYear()}-W${getWeek(d)}`
+    const monthKey = format(d, 'yyyy-MM')
+    const idx = (e.payload.general_mood?.id || 0) - 1
+    if (!weekMap[weekKey]) weekMap[weekKey] = [0,0,0,0,0]
+    if (!monthMap[monthKey]) monthMap[monthKey] = [0,0,0,0,0]
+    if (idx >= 0 && idx < 5) {
+      weekMap[weekKey][idx]++
+      monthMap[monthKey][idx]++
+    }
+  }
+
+  const moodLabels = ['Great', 'Good', 'Fine', 'Bad', 'Awful']
+  const colors = ['#4ade80','#60a5fa','#facc15','#f97316','#ef4444']
+
+  const weekLabels = Object.keys(weekMap).sort()
+  const weekData = moodLabels.map((label, i) => ({
+    label,
+    backgroundColor: colors[i],
+    data: weekLabels.map(w => weekMap[w][i])
+  }))
+
+  if (weeklyChart) weeklyChart.destroy()
+  weeklyChart = new Chart(weeklyChartRef.value.getContext('2d')!, {
+    type: 'bar',
+    data: { labels: weekLabels, datasets: weekData },
+    options: { responsive: true, stacked: true }
+  })
+
+  const monthLabels = Object.keys(monthMap).sort()
+  const monthData = moodLabels.map((label, i) => ({
+    label,
+    backgroundColor: colors[i],
+    data: monthLabels.map(m => monthMap[m][i])
+  }))
+
+  if (monthlyChart) monthlyChart.destroy()
+  monthlyChart = new Chart(monthlyChartRef.value.getContext('2d')!, {
+    type: 'bar',
+    data: { labels: monthLabels, datasets: monthData },
+    options: { responsive: true, stacked: true }
+  })
+}
+</script>


### PR DESCRIPTION
## Summary
- add `chart.js` for visualizations
- add `/analytics` page that displays weekly and monthly mood charts
- link to the analytics page from the header navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684369b9e2cc83309560758e239ec2c4