### PR TITLE
Add analytics page for mood trends

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -120,13 +120,25 @@
             <span class="text-lg font-semibold">AI chat</span>
           </NuxtLink>
           
-          <NuxtLink 
-            to="/diary" 
+          <NuxtLink
+            to="/diary"
             @click="showMobileMenu = false"
             class="flex items-center space-x-3 p-3 text-white hover:bg-[var(--highlighted)] rounded-lg transition-colors duration-200"
           >
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
             <span class="text-lg font-semibold">Diary</span>
+          </NuxtLink>
+          <NuxtLink
+            to="/analytics"
+            @click="showMobileMenu = false"
+            class="flex items-center space-x-3 p-3 text-white hover:bg-[var(--highlighted)] rounded-lg transition-colors duration-200"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M3 13.125C3 12.5037 3.50368 12 4.125 12H6.375C6.99632 12 7.5 12.5037 7.5 13.125V19.875C7.5 20.4963 6.99632 21 6.375 21H4.125C3.50368 21 3 20.4963 3 19.875V13.125Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M9.75 8.625C9.75 8.00368 10.2537 7.5 10.875 7.5H13.125C13.7463 7.5 14.25 8.00368 14.25 8.625V19.875C14.25 20.4963 13.7463 21 13.125 21H10.875C10.2537 21 9.75 20.4963 9.75 19.875V8.625Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M16.5 4.125C16.5 3.50368 17.0037 3 17.625 3H19.875C20.4963 3 21 3.50368 21 4.125V19.875C21 20.4963 20.4963 21 19.875 21H17.625C17.0037 21 16.5 20.4963 16.5 19.875V4.125Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span class="text-lg font-semibold">Analytics</span>
           </NuxtLink>
         </div>
       </div>
@@ -161,6 +173,9 @@
       </NuxtLink>
       <NuxtLink to="/diary" class="text-md font-semibold nav-link text-white duration-200 no-underline">
         Diary
+      </NuxtLink>
+      <NuxtLink to="/analytics" class="text-md font-semibold nav-link text-white duration-200 no-underline">
+        Analytics
       </NuxtLink>
       <NuxtLink to="/calendar" class="text-sm font-semibold nav-link text-white duration-200 no-underline">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vee-validate/nuxt": "^4.15.0",
         "ai": "^4.3.16",
         "base-64": "^1.0.0",
+        "chart.js": "^4.4.9",
         "cookie": "^0.7.2",
         "date-fns": "^4.1.0",
         "dompurify": "^3.2.5",
@@ -29,6 +30,7 @@
         "tailwindcss": "^4.1.4",
         "vite-tsconfig-paths": "^5.1.4",
         "vue": "^3.5.13",
+        "vue-chartjs": "^5.3.2",
         "vue-router": "^4.5.0",
         "zxcvbn": "^4.4.2"
       },
@@ -1112,6 +1114,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -3958,6 +3966,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -9990,6 +10010,16 @@
       "license": "MIT",
       "dependencies": {
         "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/vue-chartjs": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.2.tgz",
+      "integrity": "sha512-NrkbRRoYshbXbWqJkTN6InoDVwVb90C0R7eAVgMWcB9dPikbruaOoTFjFYHE/+tNPdIe6qdLCDjfjPHQ0fw4jw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "vue": "^3.0.0-0 || ^2.7.0"
       }
     },
     "node_modules/vue-devtools-stub": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vee-validate/nuxt": "^4.15.0",
     "ai": "^4.3.16",
     "base-64": "^1.0.0",
+    "chart.js": "^4.4.9",
     "cookie": "^0.7.2",
     "date-fns": "^4.1.0",
     "dompurify": "^3.2.5",
@@ -32,6 +33,7 @@
     "tailwindcss": "^4.1.4",
     "vite-tsconfig-paths": "^5.1.4",
     "vue": "^3.5.13",
+    "vue-chartjs": "^5.3.2",
     "vue-router": "^4.5.0",
     "zxcvbn": "^4.4.2"
   },

--- a/pages/analytics.vue
+++ b/pages/analytics.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { onMounted, ref, computed } from 'vue'
+import { Line } from 'vue-chartjs'
+import {
+  Chart,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js'
+import { format, parseISO } from 'date-fns'
+import MarkdownIt from 'markdown-it'
+import { useChat } from '@ai-sdk/vue'
+import { useMoodEntries } from '~/composables/useMoodEntries'
+
+Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Title, Tooltip, Legend)
+
+const md = new MarkdownIt()
+const renderMarkdown = (text: string) => md.render(text)
+
+const { finalizedEntries, fetchFinalizedMoodEntries } = useMoodEntries()
+
+const chartData = ref({ labels: [], datasets: [] })
+const chartOptions = {
+  responsive: true,
+  scales: {
+    y: { beginAtZero: true, max: 5 }
+  }
+}
+
+const { messages, input, handleSubmit } = useChat({
+  api: '/api/openai/chat-with-data',
+  experimental_prepareRequestBody: ({ id, messages, requestBody }) => ({
+    id,
+    messages,
+    ...requestBody,
+    data: { userData: finalizedEntries.value }
+  })
+})
+
+onMounted(async () => {
+  await fetchFinalizedMoodEntries()
+  updateChart()
+})
+
+function updateChart () {
+  const entries = finalizedEntries.value
+  if (!entries.length) return
+
+  const monthly: Record<string, number[]> = {}
+  for (const entry of entries) {
+    const date = parseISO(entry.payload.entry_timestamp)
+    const key = format(date, 'yyyy-MM')
+    monthly[key] = monthly[key] || []
+    monthly[key].push(entry.payload.general_mood.id)
+  }
+
+  const labels: string[] = []
+  const data: number[] = []
+  Object.keys(monthly).sort().forEach(k => {
+    labels.push(k)
+    const arr = monthly[k]
+    data.push(arr.reduce((a, b) => a + b, 0) / arr.length)
+  })
+
+  chartData.value = {
+    labels,
+    datasets: [
+      {
+        label: 'Average Mood',
+        data,
+        borderColor: '#10b981',
+        backgroundColor: 'rgba(16,185,129,0.2)'
+      }
+    ]
+  }
+}
+
+const summaryMessage = ref('')
+
+async function generateSummary () {
+  input.value = 'Provide a short summary of my recent mood trends.'
+  await handleSubmit()
+}
+
+const summaryHtml = computed(() => {
+  const aiMsg = messages.value.find(m => m.role === 'assistant')
+  return aiMsg ? renderMarkdown(aiMsg.content) : ''
+})
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto p-4 space-y-6">
+    <h1 class="text-center text-2xl font-bold mb-4">Mood Analytics</h1>
+    <div class="bg-[var(--secondary)] p-4 rounded-xl">
+      <Line :data="chartData" :options="chartOptions" />
+    </div>
+    <button
+      class="px-4 py-2 rounded bg-[var(--primary)] text-white"
+      @click="generateSummary"
+    >
+      Generate AI Summary
+    </button>
+    <div v-html="summaryHtml" class="prose prose-invert max-w-none"></div>
+  </div>
+</template>
+
+<style scoped>
+.prose :deep(p) {
+  margin: 0.5rem 0;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- visualize average mood by month with Chart.js
- display a simple AI generated summary of mood trends
- link new Analytics page in header navigation
- upgrade chart.js and vue-chartjs dependencies

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68436d2317bc833082b48b9760fa3cf7