### PR TITLE
Fix typing overlay to avoid jumpy markdown

### DIFF
--- a/components/TypingText.vue
+++ b/components/TypingText.vue
@@ -1,13 +1,8 @@
 <template>
   <span class="relative block">
     <span
-      v-html="rendered"
-      :class="['whitespace-pre-wrap', done ? '' : 'invisible']"
-    />
-    <span
-      v-if="!done"
-      v-html="renderedProgress"
-      class="absolute inset-0 whitespace-pre-wrap"
+      v-html="done ? rendered : renderedProgress"
+      class="whitespace-pre-wrap block"
     />
   </span>
 </template>


### PR DESCRIPTION
## Summary
- improve typing overlay component to render partial Markdown

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844045b006c833090676f783addb9f2