### PR TITLE
Fix password reset encryption flow

### DIFF
--- a/pages/forgot-password.vue
+++ b/pages/forgot-password.vue
@@ -4,6 +4,10 @@
       <h2>Reset your password</h2><br>
       <input v-model="email" type="email" placeholder="Your email" /><br><br>
       <button @click="sendResetEmail">Send reset link</button><br>
+      <p class="text-sm text-[var(--muted)] mt-2">
+        Resetting the password without knowing the old one will make existing
+        encrypted data unreadable.
+      </p>
       <p v-if="message">{{ message }}</p>
     </div>
   </div>

--- a/pages/reset-password.vue
+++ b/pages/reset-password.vue
@@ -23,6 +23,8 @@
 
 <script setup lang="ts">
 import zxcvbn from 'zxcvbn'
+import { useDek } from '~/composables/useDek'
+import { useDekRepair } from '~/composables/useDekRepair'
 
 definePageMeta({
   requiresAuth: false
@@ -65,10 +67,23 @@ const updatePassword = async () => {
 
   if (error) {
     message.value = error.message
-  } else {
-    message.value = 'Password updated! You can now log in.'
-    // Optional: Redirect to login
-    setTimeout(() => navigateTo('/login'), 2000)
+    return
   }
+
+  const { updateDekPassword } = useDek()
+  const { repairIfMissing } = useDekRepair()
+
+  try {
+    await updateDekPassword(password.value)
+  } catch (e) {
+    try {
+      await repairIfMissing(password.value, null, null)
+    } catch (e2) {
+      console.error('Failed to reset encryption keys', e2)
+    }
+  }
+
+  message.value = 'Password updated! You can now log in.'
+  setTimeout(() => navigateTo('/login'), 2000)
 }
 </script>


### PR DESCRIPTION
## Summary
- warn user on password reset page about encryption loss
- try to reset encryption keys after resetting the password

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684424d7c1a083309b84215ced5b2a0e