### PR TITLE
Sanitize markdown output in UI

### DIFF
--- a/pages/analytics.vue
+++ b/pages/analytics.vue
@@ -13,13 +13,14 @@ import {
 } from 'chart.js'
 import { format, parseISO } from 'date-fns'
 import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
 import { useChat } from '@ai-sdk/vue'
 import { useMoodEntries } from '~/composables/useMoodEntries'
 
 Chart.register(LineElement, PointElement, LinearScale, CategoryScale, Title, Tooltip, Legend)
 
 const md = new MarkdownIt()
-const renderMarkdown = (text: string) => md.render(text)
+const renderMarkdown = (text: string) => DOMPurify.sanitize(md.render(text))
 
 const { finalizedEntries, fetchFinalizedMoodEntries } = useMoodEntries()
 

--- a/pages/llm.vue
+++ b/pages/llm.vue
@@ -2,6 +2,7 @@
 import { useChat } from '@ai-sdk/vue';
 import { onMounted, computed } from 'vue';
 import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
 import TypingText from '~/components/TypingText.vue'
 import InfoTooltip from '~/components/InfoTooltip.vue'
 import { useMoodEntries } from '~/composables/useMoodEntries';
@@ -9,7 +10,7 @@ import { useMoodEntries } from '~/composables/useMoodEntries';
 const { finalizedEntries, fetchFinalizedMoodEntries } = useMoodEntries();
 
 const md = new MarkdownIt()
-const renderMarkdown = (text: string) => md.render(text)
+const renderMarkdown = (text: string) => DOMPurify.sanitize(md.render(text))
 
 const { input, handleSubmit, messages, addToolResult } = useChat({
   api: '/api/openai/chat-with-data',

--- a/pages/spotify.vue
+++ b/pages/spotify.vue
@@ -78,11 +78,12 @@
 <script setup lang="ts">
 import { ref, watch, computed } from 'vue'
 import MarkdownIt from 'markdown-it'
+import DOMPurify from 'dompurify'
 
 definePageMeta({ requiresAuth: false })
 
 const md = new MarkdownIt()
-const renderMarkdown = (text: string) => md.render(text)
+const renderMarkdown = (text: string) => DOMPurify.sanitize(md.render(text))
 const characters = ref('Default')
 const timeframe = ref<'short_term' | 'medium_term' | 'long_term'>('short_term')
 const { data: tracks, error: tracksError } =


### PR DESCRIPTION
## Summary
- sanitize all markdown-rendered HTML using DOMPurify
- keep v-html but render sanitized HTML for llm, analytics, and spotify pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684426a245908330aecbad4ebf0bf290