### PR TITLE
Add secure flag to auth cookies

### DIFF
--- a/server/api/auth.post.ts
+++ b/server/api/auth.post.ts
@@ -71,14 +71,16 @@ export default defineEventHandler(async (event) => {
       httpOnly: true,
       sameSite: 'lax',
       path: '/',
-      maxAge: session.expires_in
+      maxAge: session.expires_in,
+      secure: true
     })
 
     setCookie(event, REFRESH_COOKIE, session.refresh_token, {
       httpOnly: true,
       sameSite: 'lax',
       path: '/',
-      maxAge: 60 * 60 * 24 * 365 // 1 year
+      maxAge: 60 * 60 * 24 * 365, // 1 year
+      secure: true
     })
   }
 


### PR DESCRIPTION
## Summary
- ensure login cookies are marked as `secure`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684426a37fc883309d41f93d34c5a5c9