### PR TITLE
Update Spotify cookie flags

### DIFF
--- a/server/api/spotify/callback.ts
+++ b/server/api/spotify/callback.ts
@@ -36,9 +36,15 @@ export default defineEventHandler(async (event) => {
   setCookie(event, 'spotify_access_token', tokenRes.access_token, {
     httpOnly: true,
     maxAge: tokenRes.expires_in,
+    sameSite: 'lax',
+    secure: true,
+    path: '/api/spotify'
   })
   setCookie(event, 'spotify_refresh_token', tokenRes.refresh_token, {
     httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/api/spotify'
   })
 
   sendRedirect(event, '/spotify')

--- a/server/api/spotify/login.ts
+++ b/server/api/spotify/login.ts
@@ -5,7 +5,12 @@ import { randomBytes } from 'crypto'
 export default defineEventHandler((event) => {
   const { spotifyClientId, spotifyRedirectUri } = useRuntimeConfig()
   const state = randomBytes(16).toString('hex')
-  setCookie(event, 'spotify_state', state, { httpOnly: true, sameSite: 'lax' })
+  setCookie(event, 'spotify_state', state, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/api/spotify'
+  })
 
   const params = new URLSearchParams({
     response_type: 'code',


### PR DESCRIPTION
## Summary
- use secure cookies for Spotify login flow

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684426a38cc48330ac35e9402dd36cdc