### PR TITLE
Bugfix for password reset redirect

### DIFF
--- a/composables/useDek.ts
+++ b/composables/useDek.ts
@@ -172,7 +172,9 @@ export const useDek = () => {
       if (kek.value) {
         await quickUnlock();
       } else {
-        router.push({ path: '/unlock', query: { redirect: route.fullPath } });
+        if (!opts.suppressRedirect) {
+          router.push({ path: '/unlock', query: { redirect: route.fullPath } });
+        }
         throw new Error('unlock first');
       }
     }
@@ -186,7 +188,9 @@ export const useDek = () => {
       if (kek.value) {
         await quickUnlock();
       } else {
-        router.push({ path: '/unlock', query: { redirect: route.fullPath } });
+        if (!opts.suppressRedirect) {
+          router.push({ path: '/unlock', query: { redirect: route.fullPath } });
+        }
         throw new Error('unlock first');
       }
     }
@@ -195,14 +199,19 @@ export const useDek = () => {
     return JSON.parse(json) as T;
   }
 
-  async function updateDekPassword(newPassword: string) {
+  async function updateDekPassword(
+    newPassword: string,
+    opts: { suppressRedirect?: boolean } = {}
+  ) {
     if (!user.value) throw new Error('no session');
 
     if (!dek.value) {
       if (kek.value) {
         await quickUnlock();
       } else {
-        router.push({ path: '/unlock', query: { redirect: route.fullPath } });
+        if (!opts.suppressRedirect) {
+          router.push({ path: '/unlock', query: { redirect: route.fullPath } });
+        }
         throw new Error('unlock first');
       }
     }

--- a/pages/reset-password.vue
+++ b/pages/reset-password.vue
@@ -74,7 +74,7 @@ const updatePassword = async () => {
   const { repairIfMissing } = useDekRepair()
 
   try {
-    await updateDekPassword(password.value)
+    await updateDekPassword(password.value, { suppressRedirect: true })
   } catch (e) {
     try {
       await repairIfMissing(password.value, null, null)


### PR DESCRIPTION
## Summary
- add optional `suppressRedirect` parameter for `updateDekPassword`
- avoid unlocking redirect during password reset

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684437d04cd08330b0b7066a47342d47