### PR TITLE
Improve login error messages

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -103,6 +103,7 @@ import { useDekRepair }          from '~/composables/useDekRepair';
 import { usePublicContextData }  from '~/composables/usePublicContextData';
 
 import { saveSalt, clearSalt }   from '~/utils/cryptoHelpers';
+import { extractErrorMessage }   from '~/utils/errorHelpers';
 
 const router     = useRouter();
 const supabase   = useSupabaseClient();
@@ -187,7 +188,7 @@ async function handleAuth() {
     }
 
   } catch (err: any) {
-    errorMsg.value = err.message ?? 'Unexpected error';
+    errorMsg.value = extractErrorMessage(err)
   } finally {
     password.value = '';
     confirmPassword.value = '';

--- a/utils/errorHelpers.ts
+++ b/utils/errorHelpers.ts
@@ -1,0 +1,10 @@
+export function extractErrorMessage(err: any, fallback = 'Unexpected error'): string {
+  if (err?.data?.statusMessage) return err.data.statusMessage
+  if (err?.statusMessage) return err.statusMessage
+  if (err?.statusText) return err.statusText
+  if (typeof err?.message === 'string') {
+    const match = err.message.match(/^[^:]+:\s\d+\s+(.*)$/)
+    return match ? match[1] : err.message
+  }
+  return fallback
+}


### PR DESCRIPTION
## Summary
- add helper to extract API error messages
- show friendlier messages during login and registration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68444657fb048330a8ccf480e3d917f9