### PR TITLE
Fix footer overlap on llm page

### DIFF
--- a/pages/llm.vue
+++ b/pages/llm.vue
@@ -160,7 +160,7 @@ const messageList = computed(() => messages.value); // computed property for typ
 
     <form
       @submit="handleSubmit"
-      class="fixed bottom-0 left-0 right-0 max-w-xl lg:max-w-2xl mx-auto p-4 bg-[var(--bg)] border-t border-[var(--border)]"
+      class="sticky bottom-0 left-0 right-0 max-w-xl lg:max-w-2xl mx-auto p-4 bg-[var(--bg)] border-t border-[var(--border)]"
     >
       <input
         class="w-full p-3 rounded-lg bg-[var(--input-bg)] text-[var(--input-color)] border border-[var(--input-border)]"


### PR DESCRIPTION
## Summary
- ensure footer isn't covered by input on `/llm`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68444f543a688330a0e632feac9f859a