### PR TITLE
Move chat input above footer

### DIFF
--- a/pages/llm.vue
+++ b/pages/llm.vue
@@ -31,7 +31,7 @@ const messageList = computed(() => messages.value); // computed property for typ
 </script>
 
 <template>
-  <div class="relative max-w-xl lg:max-w-2xl mx-auto p-4 sm:p-6">
+  <div class="relative flex flex-col min-h-full max-w-xl lg:max-w-2xl mx-auto p-4 sm:p-6">
     <h1 class="text-center text-2xl font-bold mb-4">Pseudo-psychiatrist</h1>
     <p class="text-sm text-gray-500 mb-4 flex flex-wrap items-center gap-1">
       You can ask ChatGPT to get all your data
@@ -44,7 +44,7 @@ const messageList = computed(() => messages.value); // computed property for typ
       </InfoTooltip>
       ;)
     </p>
-    <div class="space-y-4 pb-24">
+    <div class="flex-1 space-y-4 pb-24">
       <div
         v-for="message in messageList"
         :key="message.id"


### PR DESCRIPTION
## Summary
- give chat input some space above footer so it doesn't touch

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844508cd50c8330827ed74354ad6e4d