### PR TITLE
Fix analytics mood scale

### DIFF
--- a/pages/analytics.vue
+++ b/pages/analytics.vue
@@ -28,7 +28,12 @@ const chartData = ref({ labels: [], datasets: [] })
 const chartOptions = {
   responsive: true,
   scales: {
-    y: { beginAtZero: true, max: 5 }
+    y: {
+      beginAtZero: false,
+      min: 1,
+      max: 5,
+      reverse: true
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- flip mood chart scale so 1 is highest and 5 is lowest in `/analytics`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68455bb3b78883308670fe884657c9dc