### PR TITLE
Add animations across pages

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,19 @@
 <!-- app.vue -->
 <template>
   <NuxtLayout>
-    <NuxtPage />
+    <NuxtPage :transition="pageTransition" />
   </NuxtLayout>
 </template>
+
+<script setup>
+const pageTransition = { name: 'fade', mode: 'out-in' }
+</script>
+
+<style>
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -154,3 +154,27 @@ html[data-theme='dark'] {
 .btn--active {
   box-shadow: inset 0 -2px 0 var(--fg);
 }
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fade-in 0.5s ease-out;
+}
+
+.slide-up {
+  animation: slide-up 0.5s ease-out;
+}

--- a/components/AppFooter.vue
+++ b/components/AppFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="border-t border-[var(--border)] bg-[var(--secondary)] text-[var(--muted)]">
+  <footer class="border-t border-[var(--border)] bg-[var(--secondary)] text-[var(--muted)] fade-in">
     <div class="max-w-screen-xl mx-auto px-4 py-6 flex flex-col items-center space-y-2">
       <p
         class="text-sm cursor-pointer select-none"

--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-<nav class="bg-transparent text-white px-6 py-4" aria-label="Main menu">
+<nav class="bg-transparent text-white px-6 py-4 fade-in" aria-label="Main menu">
   <div class="max-w-screen-xl mx-auto flex items-center justify-between">
     <!-- Mobile Layout -->
     <div class="flex md:hidden items-center justify-between w-full">

--- a/components/HelloUser.vue
+++ b/components/HelloUser.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="user" class="grid place-items-center">
-    <p class="text-4xl font-extrabold text-gray-900 dark:text-white">
+    <p class="text-4xl font-extrabold text-gray-900 dark:text-white slide-up">
       Welcome,<br />
       {{ username || user.email }} 😀
     </p>

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="min-h-screen flex items-center justify-center px-4">
+  <section class="min-h-screen flex items-center justify-center px-4 fade-in">
     <div class="max-w-md w-full space-y-6 bg-[var(--secondary)] p-6 sm:p-8 rounded-3xl shadow-2xl">
       <h2 class="text-2xl font-bold text-center">
         {{ isLogin ? 'Login' : 'Register' }}

--- a/pages/welcome.vue
+++ b/pages/welcome.vue
@@ -1,6 +1,6 @@
 <!-- Improved welcome page design -->
 <template>
-  <section class="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4 py-8">
+  <section class="min-h-[calc(100vh-4rem)] flex items-center justify-center px-4 py-8 fade-in">
     <div class="w-full max-w-2xl space-y-6 bg-[var(--secondary)] p-6 sm:p-8 rounded-3xl shadow-2xl">
       <HelloUser />
       <p class="text-center text-lg text-[var(--muted)]">


### PR DESCRIPTION
## Summary
- add global page transitions
- implement fade-in/slide-up CSS animations
- animate header, footer, login, and welcome page
- animate greeting text on welcome page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68455bce35088330a44bfda24e2ffc8a