### PR TITLE
Add confetti effect on mood submission

### DIFF
--- a/components/NoteConfirmation.vue
+++ b/components/NoteConfirmation.vue
@@ -18,6 +18,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import confetti from 'canvas-confetti'
 import { useRouter } from 'vue-router'
 import { useDek } from '~/composables/useDek'
 import { useSupabaseClient } from '#imports'
@@ -64,7 +65,7 @@ async function submit() {
       }
     })
 
-    // 700 hydradtion errora za sekundu
+    confetti()
     await router.push('/calendar')
   } catch (err: any) {
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vee-validate/nuxt": "^4.15.0",
         "ai": "^4.3.16",
         "base-64": "^1.0.0",
+        "canvas-confetti": "^1.9.2",
         "chart.js": "^4.4.9",
         "cookie": "^0.7.2",
         "date-fns": "^4.1.0",
@@ -3929,6 +3930,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.2.tgz",
+      "integrity": "sha512-6Xi7aHHzKwxZsem4mCKoqP6YwUG3HamaHHAlz1hTNQPCqXhARFpSXnkC9TWlahHY5CG6hSL5XexNjxK8irVErg==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vee-validate/nuxt": "^4.15.0",
     "ai": "^4.3.16",
     "base-64": "^1.0.0",
+    "canvas-confetti": "^1.9.2",
     "chart.js": "^4.4.9",
     "cookie": "^0.7.2",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Summary
- install `canvas-confetti`
- trigger confetti when a mood entry is successfully saved

## Testing
- `npm install canvas-confetti@1.9.2 --save`

------
https://chatgpt.com/codex/tasks/task_e_68455dadf3fc83308d9903c166ae5b01