### PR TITLE
Fix mismatched salt generation

### DIFF
--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -164,16 +164,16 @@ async function handleAuth() {
         refresh_token: session.refresh_token,
       });
 
+      const { repairIfMissing } = useDekRepair();
+      const res = await repairIfMissing(userPassword, salt, wrappedDek);
+      const actualSalt = res?.salt ?? salt;
+
       await unlock(userPassword);
 
-      const { repairIfMissing } = useDekRepair();
-      await repairIfMissing(userPassword, salt, wrappedDek);
-
-      // spremi KEK NAVODNO, kek nestane brže nego Amelia Earhart
-      if (salt) {
-        await storeKek(userPassword, salt);
-        await saveSalt(salt);
-      } else {
+      // persist KEK and salt for quick unlock
+      if (actualSalt) {
+        await storeKek(userPassword, actualSalt);
+        await saveSalt(actualSalt);
       }
     } else {
     }

--- a/composables/useDekRepair.ts
+++ b/composables/useDekRepair.ts
@@ -12,12 +12,12 @@ export function useDekRepair() {
     password: string,
     saltB64: string | null,
     wrappedDekB64: string | null
-  ) {
+  ): Promise<{ salt: string; wrappedDek: string } | undefined> {
     startDecryptAnimation()
     try {
     if (saltB64 && wrappedDekB64) {
       await saveSalt(saltB64);
-      return;
+      return { salt: saltB64, wrappedDek: wrappedDekB64 };
     }
 
     const salt = makeSalt();
@@ -37,6 +37,7 @@ export function useDekRepair() {
 
 
     await saveSalt(salt);
+    return { salt, wrappedDek };
     } finally {
       stopDecryptAnimation()
     }


### PR DESCRIPTION
## Summary
- fix `repairIfMissing` to return generated salt and wrapped DEK
- ensure register/login keep same salt by repairing profile before unlocking

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845eaef6d4883309ed9ddd5ad0a79c3