### PR TITLE
Add mood entry deletion

### DIFF
--- a/components/MoodCalendar.vue
+++ b/components/MoodCalendar.vue
@@ -186,14 +186,21 @@
       </div>
     </div>
 
-    <div class="mt-auto pt-4 border-t border-[var(--border)]">
-      <button
-        @click="closeEntryModal"
-        class="w-full sm:w-auto px-4 py-2 rounded bg-[var(--border)] hover:bg-[var(--muted)] text-[var(--fg)] transition touch-manipulation"
-      >
-        Close
-      </button>
-    </div>
+      <div class="mt-auto pt-4 border-t border-[var(--border)] flex gap-2">
+        <button
+          @click="deleteSelectedEntry"
+          :disabled="deleting"
+          class="w-full sm:w-auto px-4 py-2 rounded bg-red-600 hover:bg-red-700 text-white transition touch-manipulation disabled:opacity-50"
+        >
+          {{ deleting ? 'Deleting…' : 'Delete' }}
+        </button>
+        <button
+          @click="closeEntryModal"
+          class="w-full sm:w-auto px-4 py-2 rounded bg-[var(--border)] hover:bg-[var(--muted)] text-[var(--fg)] transition touch-manipulation"
+        >
+          Close
+        </button>
+      </div>
   </div>
 </div>
 </template>
@@ -332,6 +339,23 @@
     } finally {
       loadingEntryByYear.value = false;
     }
+}
+
+const deleting = ref(false);
+
+async function deleteSelectedEntry() {
+  if (selectedEntryId.value === null) return;
+  if (!confirm('Delete this entry?')) return;
+  deleting.value = true;
+  try {
+    await $fetch(`/api/mood-entry/${selectedEntryId.value}`, { method: 'DELETE' });
+    await fetchEntriesByYear();
+    closeEntryModal();
+  } catch (err: any) {
+    alert(err.message || 'Failed to delete entry');
+  } finally {
+    deleting.value = false;
+  }
 }
 
 

--- a/server/api/mood-entry/[id].delete.ts
+++ b/server/api/mood-entry/[id].delete.ts
@@ -1,0 +1,34 @@
+// server/api/mood-entry/[id].delete.ts
+import { defineEventHandler, getRouterParam, createError } from 'h3'
+import { serverSupabaseClient } from '#supabase/server'
+
+export default defineEventHandler(async (event) => {
+  const supabase = await serverSupabaseClient(event)
+
+  const {
+    data: { user },
+    error: authError
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  }
+
+  const id = Number(getRouterParam(event, 'id'))
+
+  if (isNaN(id)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid ID' })
+  }
+
+  const { error } = await supabase
+    .from('mood_entries')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id)
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: error.message })
+  }
+
+  return { success: true, message: 'Deleted successfully' }
+})


### PR DESCRIPTION
## Summary
- add API to delete mood entries
- enable deleting mood entries from MoodCalendar

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846b7ac187483308b8d44c891a35fdb